### PR TITLE
Turn Name, Team and Bucket name into variables

### DIFF
--- a/TF Primer.ipynb
+++ b/TF Primer.ipynb
@@ -443,7 +443,11 @@
    "metadata": {},
    "source": [
     "### Terraform Apply \n",
-    "Create resources\n"
+    "Create resources  \n",
+    "You will be prompted for Name, Team, and a Prefix for the Bucket Name.  \n",
+    "If you would like to avoid the prompt, create a terraform.tfvars file with the variables pre-loaded.  \n",
+    "The prefix can only be composed of lowercase letters and '-'.  \n",
+    "A random string will be appended to make the name globally unique.  \n"
    ]
   },
   {

--- a/main.tf
+++ b/main.tf
@@ -21,16 +21,11 @@ provider "aws" {
   default_tags {
     tags = {
       Environment = "Sandbox"
-      Owner = "ray.ryjewski"
-      Team = "SE"
+      Owner = "daniel.chan"
+      Team = "CSE"
       Project = "Internal"
     }
   }
-
-  # Set Environment Variables in your terminal for Auth
-    # export AWS_ACCESS_KEY_ID="anaccesskey"
-    # export AWS_SECRET_ACCESS_KEY="asecretkey"
-    # export AWS_SESSION_TOKEN="aSessionToken"
 }
 
 # Module Doc - https://registry.terraform.io/modules/hashicorp/dir/template/latest
@@ -45,9 +40,16 @@ module "sample_files" {
 ## S3 Bucket Setup
 ##################
 
+# random string resource
+resource "random_string" "random_gen" {
+  length = 8
+  special  = false
+  upper = false
+}
+
 # Create the S3 Bucket
 resource "aws_s3_bucket" "private_bucket" {
-    bucket = "rkr-priviate-bucket"
+    bucket = "djc-test-bucket-${random_string.random_gen.result}"
     # acl = "private"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,8 @@ provider "aws" {
   default_tags {
     tags = {
       Environment = "Sandbox"
-      Owner = "daniel.chan"
-      Team = "CSE"
+      Owner = var.name
+      Team = var.team
       Project = "Internal"
     }
   }
@@ -49,7 +49,7 @@ resource "random_string" "random_gen" {
 
 # Create the S3 Bucket
 resource "aws_s3_bucket" "private_bucket" {
-    bucket = "djc-test-bucket-${random_string.random_gen.result}"
+    bucket = "${var.bucket_name_prefix}-${random_string.random_gen.result}"
     # acl = "private"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  description = "Your Name"
+  type        = string
+}
+
+variable "team" {
+  description = "Your Team"
+  type        = string
+}
+
+variable "bucket_name_prefix" {
+  description = "Prefix to the name of the S3 Bucket (lowercase letters only). A random string will be appended to make the name globally unique"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z-]+$", var.bucket_name_prefix))
+    error_message = "Prefix for the bucket name can only contain lowercase letters and hyphens."
+  }
+}


### PR DESCRIPTION
This update turns the Owner tag, Team tag, and Bucket Name into variables provided by the user.
For the bucket name, a random string of 8 characters is appended to ensure the bucket name is globally unique.

Instructions in TF Primer are also updated.